### PR TITLE
Fix issue #20

### DIFF
--- a/gwu/listbox.go
+++ b/gwu/listbox.go
@@ -180,13 +180,13 @@ func (c *listBoxImpl) ClearSelected() {
 }
 
 func (c *listBoxImpl) preprocessEvent(event Event, r *http.Request) {
+	c.ClearSelected()
 	value := r.FormValue(paramCompValue)
 	if len(value) == 0 {
 		return
 	}
 
 	// Set selected indices
-	c.ClearSelected()
 	for _, sidx := range strings.Split(value, ",") {
 		if idx, err := strconv.Atoi(sidx); err == nil {
 			c.selected[idx] = true


### PR DESCRIPTION
The last item unselected in a list box via ctrl+click was remaining active, due to the event processing function returning before the internal selections map was cleared.