### PR TITLE
Quick and dirty solution to allow changes to listbox contents

### DIFF
--- a/gwu/listbox.go
+++ b/gwu/listbox.go
@@ -77,6 +77,9 @@ type ListBox interface {
 
 	// ClearSelected deselects all values.
 	ClearSelected()
+	
+	// SetContent(content []string)
+	SetContent(content []string)
 }
 
 // ListBox implementation.
@@ -100,6 +103,11 @@ func NewListBox(values []string) ListBox {
 	c.AddSyncOnETypes(ETypeChange)
 	c.Style().AddClass("gwu-ListBox")
 	return c
+}
+
+func	(c *listBoxImpl)SetContent(newvalues [] string)	{
+	c.values=newvalues
+	c.selected=make([]bool,len(newvalues))
 }
 
 func (c *listBoxImpl) Multi() bool {


### PR DESCRIPTION
Added member function SetContent([]string) to ListBox so the contents of the listbox can be amended once setup.
Only a quick and dirty solution to allow changes to a listbox contents once the listbox has been created. Only allows overwriting the complete contents, but was good enough for my needs.