### PR TITLE
Fix "Empty string passed to getElementById"

### DIFF
--- a/gwu/js.go
+++ b/gwu/js.go
@@ -218,7 +218,7 @@ function sbtnVal(event, onBtnId, offBtnId) {
 }
 
 function focusComp(compId) {
-	if (compId != null) {
+	if (compId != null && compId !== "") {
 		var e = document.getElementById(compId);
 		if (e) // Else component removed or not visible (e.g. on inactive tab of TabPanel)
 			e.focus();


### PR DESCRIPTION
When using a timer to refresh a label an "Empty string passed to getElementById" showed up before each request